### PR TITLE
Add files needed to get pfunit unit tests to work

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -2,7 +2,12 @@
 # source files that are currently used in unit tests
 
 list(APPEND clm_sources
+  FatesGlobals.F90
+  EDTypesMod.F90
   EDPftvarcon.F90
+  FatesConstantsMod.F90
+  FatesHydraulicsMemMod.F90
+  FatesParametersInterface.F90
   )
 
 sourcelist_to_parent(clm_sources)


### PR DESCRIPTION
A few additional files need to be added to get the pfunit testing to work.